### PR TITLE
Correct chip revision code

### DIFF
--- a/ESP32_Version/ESP32_Version.ino
+++ b/ESP32_Version/ESP32_Version.ino
@@ -9,7 +9,7 @@
 
 int getChipRevision()
 {
-  return (REG_READ(EFUSE_BLK0_RDATA3_REG) >> (EFUSE_RD_CHIP_VER_RESERVE_S)&&EFUSE_RD_CHIP_VER_RESERVE_V) ;
+  return (REG_READ(EFUSE_BLK0_RDATA3_REG) >> EFUSE_RD_CHIP_VER_REV1_S & EFUSE_RD_CHIP_VER_REV1_V) ;
 }
 
 void setup() {
@@ -18,11 +18,11 @@ void setup() {
   Serial.print("REG_READ(EFUSE_BLK0_RDATA3_REG) ");
   Serial.println(REG_READ(EFUSE_BLK0_RDATA3_REG), BIN);
 
-  Serial.print("EFUSE_RD_CHIP_VER_RESERVE_S ");
-  Serial.println(EFUSE_RD_CHIP_VER_RESERVE_S, BIN);
+  Serial.print("EFUSE_RD_CHIP_VER_REV1_S ");
+  Serial.println(EFUSE_RD_CHIP_VER_REV1_S, BIN);
 
-  Serial.print("EFUSE_RD_CHIP_VER_RESERVE_V ");
-  Serial.println(EFUSE_RD_CHIP_VER_RESERVE_V, BIN);
+  Serial.print("EFUSE_RD_CHIP_VER_REV1_V ");
+  Serial.println(EFUSE_RD_CHIP_VER_REV1_V, BIN);
 
    Serial.println();
 


### PR DESCRIPTION
EFUSE_RD_CHIP_VER_REV1 and not EFUSE_RD_CHIP_VER_RESERVE is the reference to the ESP32 revision bit. Setting EFUSE_RD_BLK3_PART_RESERVE indicates that BLOCK3[143:96] is reserved for internal use.

& is the bitwise operator and && the logical.